### PR TITLE
Do not require a fixed version of PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"license": "GPL-2.0+",
 	"require": {
 		"php": ">= 5.5.9",
-		"squizlabs/php_codesniffer": "2.5.1"
+		"squizlabs/php_codesniffer": "^2.5.1"
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "0.9.*",


### PR DESCRIPTION
This forced all users of the package to use a specific PHPCS version. We're using this for our fundraising software at WMDE and want to use PHPCS ~2.6.
