### PR TITLE
Fix documentation of ExtendClassUsageSniff

### DIFF
--- a/MediaWiki/Sniffs/Usage/ExtendClassUsageSniff.php
+++ b/MediaWiki/Sniffs/Usage/ExtendClassUsageSniff.php
@@ -2,7 +2,7 @@
 /**
  * Report warnings when unexpected function or variable used like.
  * Should use $this->msg() rather than wfMessage() on ContextSource extend.
- * Should use $this->getUser() rather than $wgUser() on ContextSource extend.
+ * Should use $this->getUser() rather than $wgUser on ContextSource extend.
  * Should use $this->getRequest() rather than $wgRequest on ContextSource extend.
  */
 


### PR DESCRIPTION
Fix typo - $wgUser is an object, it isn't callable.